### PR TITLE
emtpy line caused both a warning and an improper build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
 RUN set -ex && \
   # Add ots user
   useradd -U -s /bin/false ots && \
-
+  \
   # Create directories
   mkdir -p /etc/onetime /var/log/onetime /var/run/onetime /var/lib/onetime /var/lib/onetime/redis && \
   chown ots /etc/onetime /var/log/onetime /var/run/onetime /var/lib/onetime /var/lib/onetime/redis


### PR DESCRIPTION
Resolves an issue with the Dockerfile that prevented the user from being added as well as silences a docker warning.