### PR TITLE
Fix the Redis error on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,11 @@ USER ots
 
 # Download and install latest OTS
 RUN set -ex && \
-  curl https://codeload.github.com/onetimesecret/onetimesecret/legacy.tar.gz/master -o /tmp/ots.tar.gz && \
+  # Get the latest commit we are aware of (previously this grabbed master, which is a moving target)
+  # I don't get the latest official "release" (2016-11-14 at the time of this writing) because that actually 
+  # had some errors installing/compiling eventmachine
+  # -L tells curl to follow redirects
+  curl -L https://github.com/onetimesecret/onetimesecret/archive/8ba0511e74b64280003691251dd99b04915d42ea.tar.gz -o /tmp/ots.tar.gz && \
   tar xzf /tmp/ots.tar.gz -C /var/lib/onetime --strip-components=1 && \
   rm /tmp/ots.tar.gz && \
   cd /var/lib/onetime && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,12 @@ RUN set -ex && \
   bundle install --frozen --deployment --without=dev --gemfile /var/lib/onetime/Gemfile && \
   cp -R etc/* /etc/onetime/
 
-ADD entrypoint.sh /usr/bin/
+# Copy our own config files over the config files that OTS put in there
+# By default, these are owned by root, but we tell Docker to have the ots user own them instead
+COPY --chown=ots:ots config.example /etc/onetime/config
+COPY --chown=ots:ots redis.conf.example /etc/onetime/redis.conf
+
+COPY entrypoint.sh /usr/bin/
 
 VOLUME /etc/onetime /var/lib/onetime/redis
 


### PR DESCRIPTION
Fixes #2 
Also, install a particular commit (https://github.com/onetimesecret/onetimesecret/commit/8ba0511e74b64280003691251dd99b04915d42ea) of OTS during build-time instead of always installing master.